### PR TITLE
Fix broken print links

### DIFF
--- a/en/step_1.md
+++ b/en/step_1.md
@@ -30,7 +30,7 @@ Completion of this project will earn you points towards your bronze "Digital Mak
 
 ### Additional information for educators
 
-If you need to print this project, please use the [printer-friendly version](https://projects.raspberrypi.org/en/projects/project-name/print){:target="_blank"}.
+If you need to print this project, please use the [printer-friendly version](https://projects.raspberrypi.org/en/projects/turtle-race/print){:target="_blank"}.
 
 Use the link in the footer to access the GitHub repository for this project, which contains all resources (including an example finished project) in the 'en/resources' folder.
 

--- a/pl-PL/step_1.md
+++ b/pl-PL/step_1.md
@@ -26,7 +26,7 @@ Ten projekt obejmuje elementy z następujących wątków z [Raspberry Pi Digital
 
 ### Dodatkowe informacje dla nauczycieli
 
-Jeśli chcesz wydrukować ten projekt, użyj [wersji do druku](https://projects.raspberrypi.org/en/projects/project-name/print){:target="_blank"}.
+Jeśli chcesz wydrukować ten projekt, użyj [wersji do druku](https://projects.raspberrypi.org/en/projects/turtle-race/print){:target="_blank"}.
 
 Skorzystaj z odnośnika w stopce, aby uzyskać dostęp do repozytorium kodu tego projektu w serwisie GitHub. Repozytorium to zawiera wszystkie zasoby (w tym przykład gotowego projektu) w folderze 'pl-PL/resources'.
 


### PR DESCRIPTION
Pointing to `project-name` rather than `turtle-race`