### PR TITLE
Fix printer friendly hyperlink

### DIFF
--- a/en/step_1.md
+++ b/en/step_1.md
@@ -36,4 +36,4 @@ Use the link in the footer to access the GitHub repository for this project, whi
 
 ### Additional information for club leaders
 
-If you need to print this project, please use the [Printer friendly version](https://projects.raspberry-pi.org/en/projects/turtle-race/print).
+If you need to print this project, please use the [Printer friendly version](https://projects.raspberrypi.org/en/projects/turtle-race/print).


### PR DESCRIPTION
Make it point to **raspberrypi**.org

_(instead of the incorrect **raspberry-pi**.org)_